### PR TITLE
INT-790 Format the oldData in the Codemod Engine Node

### DIFF
--- a/apps/nne/src/compositeModRunner.ts
+++ b/apps/nne/src/compositeModRunner.ts
@@ -155,13 +155,9 @@ export const runCompositeMod = async (
 					continue;
 				}
 
-				const modCommand = await runCodemod(
-					file.path,
-					file.newData,
-					mod,
-				);
+				const modCommands = runCodemod(mod, file.path, file.newData);
 
-				files = handleModCommands(files, modCommand).slice();
+				files = handleModCommands(files, modCommands).slice();
 			}
 		}
 	}

--- a/apps/nne/src/executeWorkerThread.ts
+++ b/apps/nne/src/executeWorkerThread.ts
@@ -160,12 +160,7 @@ export const executeWorkerThread = () => {
 					mod.transformer &&
 					mod.withParser
 				) {
-					commands = await runCodemod(
-						// outputDirectoryPath,
-						filePath,
-						oldSource,
-						mod as any, // TODO fixme
-					);
+					commands = runCodemod(mod, filePath, oldSource).slice();
 				} else if (
 					mod.engine === 'filemod-engine' &&
 					mod.transformer &&

--- a/apps/nne/src/messages.ts
+++ b/apps/nne/src/messages.ts
@@ -11,8 +11,9 @@ export const enum MessageKind {
 export type RewriteMessage = Readonly<{
 	k: MessageKind.rewrite; // kind
 	i: string; // (input) file path
-	o: string; // output file path
+	o: string; // output file path (newDataPath)
 	c: string;
+	oldDataPath: string;
 }>;
 
 export type FinishMessage = Readonly<{


### PR DESCRIPTION
1. Use the default Prettier config (by Intuita) per file when no config is found or the found config is empty
2. Reformat the oldData of a file using the TS Morph utilities and then run the TS Morph codemod on that reformatted content so the user can see the minimum number of changes in the diff view
3. Format the oldData and the newData using the same prettier config (this is already implemented, but will be affected by bulletpoint 1)