### PR TITLE
INT-1421 ensure that the CLI finishes if a thread is stuck

### DIFF
--- a/src/executeWorkerThread.ts
+++ b/src/executeWorkerThread.ts
@@ -8,14 +8,14 @@ import { buildFormattedFileCommands } from './fileCommands.js';
 import { getTransformer } from './getTransformer.js';
 
 const messageHandler = async (m: unknown) => {
-	const message = decodeMainThreadMessage(m);
-
-	if (message.kind === 'exit') {
-		parentPort?.off('message', messageHandler);
-		return;
-	}
-
 	try {
+		const message = decodeMainThreadMessage(m);
+
+		if (message.kind === 'exit') {
+			parentPort?.off('message', messageHandler);
+			return;
+		}
+
 		const transformer = getTransformer(message.codemodSource);
 
 		const fileCommands =
@@ -46,14 +46,9 @@ const messageHandler = async (m: unknown) => {
 			parentPort?.postMessage({
 				kind: 'error',
 				message: error.message,
-			} satisfies WorkerThreadMessage)
+			} satisfies WorkerThreadMessage);
 		}
-		// TODO
 	}
-
-	parentPort?.postMessage({
-		kind: 'idleness',
-	} satisfies WorkerThreadMessage);
 };
 
 export const executeWorkerThread = () => {

--- a/src/workerThreadMessages.ts
+++ b/src/workerThreadMessages.ts
@@ -6,9 +6,6 @@ const workerThreadMessageSchema = S.union(
 		commands: S.unknown,
 	}),
 	S.struct({
-		kind: S.literal('idleness'),
-	}),
-	S.struct({
 		kind: S.literal('error'),
 		message: S.string,
 	}),


### PR DESCRIPTION
Changes:
1) there is no idlessness message, if a thread sends the commands or an error, we consider such a sending thread to be idle.
2) we count the number of truly processed files (they are processed only if the thread returns commands)
3) if the threads are idle for 5s, we shut down the codemod execution