### PR TITLE
feat: INT-2195 add logs to guide user to vsce

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 		"prettier": "^2.8.7",
 		"rehype-parse": "^8.0.4",
 		"tar": "^6.1.15",
+		"terminal-link": "^3.0.0",
 		"ts-morph": "18.0.0",
 		"unified": "^10.1.2",
 		"unist-util-filter": "^5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ dependencies:
   tar:
     specifier: ^6.1.15
     version: 6.1.15
+  terminal-link:
+    specifier: ^3.0.0
+    version: 3.0.0
   ts-morph:
     specifier: 18.0.0
     version: 18.0.0
@@ -2247,6 +2250,13 @@ packages:
     resolution: {integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==}
     engines: {node: '>=6'}
     dev: true
+
+  /ansi-escapes@5.0.0:
+    resolution: {integrity: sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==}
+    engines: {node: '>=12'}
+    dependencies:
+      type-fest: 1.4.0
+    dev: false
 
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -4672,6 +4682,14 @@ packages:
     dependencies:
       has-flag: 4.0.0
 
+  /supports-hyperlinks@2.3.0:
+    resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
+    engines: {node: '>=8'}
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+    dev: false
+
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -4694,6 +4712,14 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       rimraf: 2.6.3
+    dev: false
+
+  /terminal-link@3.0.0:
+    resolution: {integrity: sha512-flFL3m4wuixmf6IfhFJd1YPiLiMuxEc8uHRM1buzIeZPm22Au2pDqBJQgdo7n1WfPU1ONFGv7YDwpFBmHGF6lg==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-escapes: 5.0.0
+      supports-hyperlinks: 2.3.0
     dev: false
 
   /text-table@0.2.0:
@@ -4789,6 +4815,11 @@ packages:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
     dev: true
+
+  /type-fest@1.4.0:
+    resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
+    engines: {node: '>=10'}
+    dev: false
 
   /typescript@5.2.2:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -58,18 +58,25 @@ export class Runner {
 	}
 
 	public async run() {
-		try {
-			if (this._dryRun) {
-				this._printer.printConsoleMessage(
-					'log',
-					terminalLink(
-						'Click to view results of this run in VSCode extension',
-						`vscode://intuita.intuita-vscode-extension/case/${this.__caseHashDigest}`,
-					),
-				);
-			}
+		const EXTENSION_LINK_START = terminalLink(
+			'Click to view the live results of this run in the Intuita VSCode Extension!',
+			`vscode://intuita.intuita-vscode-extension/case/${this.__caseHashDigest}`,
+		);
 
+		const EXTENSION_LINK_END = terminalLink(
+			'The run has finished! Click to open the Intuita VSCode Extension and view the results.',
+			`vscode://intuita.intuita-vscode-extension/case/${this.__caseHashDigest}`,
+		);
+
+		try {
 			if (this._codemodSettings.kind === 'runSourced') {
+				if (this._dryRun) {
+					this._printer.printConsoleMessage(
+						'log',
+						EXTENSION_LINK_START,
+					);
+				}
+
 				const codemodOptions = await buildSourcedCodemodOptions(
 					this._fs,
 					this._codemodSettings,
@@ -98,6 +105,13 @@ export class Runner {
 					executionId: this.__caseHashDigest.toString('base64url'),
 					fileCount: this.__modifiedFileCount,
 				});
+
+				if (this._dryRun) {
+					this._printer.printConsoleMessage(
+						'log',
+						EXTENSION_LINK_END,
+					);
+				}
 
 				return;
 			}
@@ -149,6 +163,13 @@ export class Runner {
 					`Executing the "${this._name}" codemod against "${this._flowSettings.targetPath}"`,
 				);
 
+				if (this._dryRun) {
+					this._printer.printConsoleMessage(
+						'log',
+						EXTENSION_LINK_START,
+					);
+				}
+
 				const codemod = await this._codemodDownloader.download(
 					this._name,
 					this._flowSettings.useCache,
@@ -177,16 +198,13 @@ export class Runner {
 					executionId: this.__caseHashDigest.toString('base64url'),
 					fileCount: this.__modifiedFileCount,
 				});
-			}
 
-			if (this._dryRun) {
-				this._printer.printConsoleMessage(
-					'log',
-					terminalLink(
-						'Run has finished! Click to open VSCode extension and view the results',
-						`vscode://intuita.intuita-vscode-extension/case/${this.__caseHashDigest}`,
-					),
-				);
+				if (this._dryRun) {
+					this._printer.printConsoleMessage(
+						'log',
+						EXTENSION_LINK_END,
+					);
+				}
 			}
 		} catch (error) {
 			if (!(error instanceof Error)) {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,4 +1,7 @@
 import { randomBytes } from 'crypto';
+import { join } from 'path';
+import terminalLink from 'terminal-link';
+
 import type { ArgumentRecord } from './schemata/argumentRecordSchema.js';
 import {
 	modifyFileSystemUponCommand,
@@ -17,7 +20,6 @@ import type { FlowSettings } from './schemata/flowSettingsSchema.js';
 import type { TelemetryBlueprint } from './telemetryService.js';
 import { buildSourcedCodemodOptions } from './buildCodemodOptions.js';
 import { RunSettings } from './runSettings.js';
-import { join } from 'path';
 
 export class Runner {
 	private __caseHashDigest: Buffer;
@@ -57,6 +59,16 @@ export class Runner {
 
 	public async run() {
 		try {
+			if (this._dryRun) {
+				this._printer.printConsoleMessage(
+					'log',
+					terminalLink(
+						'Click to view results of this run in VSCode extension',
+						`vscode://intuita.intuita-vscode-extension/case/${this.__caseHashDigest}`,
+					),
+				);
+			}
+
 			if (this._codemodSettings.kind === 'runSourced') {
 				const codemodOptions = await buildSourcedCodemodOptions(
 					this._fs,
@@ -165,6 +177,16 @@ export class Runner {
 					executionId: this.__caseHashDigest.toString('base64url'),
 					fileCount: this.__modifiedFileCount,
 				});
+			}
+
+			if (this._dryRun) {
+				this._printer.printConsoleMessage(
+					'log',
+					terminalLink(
+						'Run has finished! Click to open VSCode extension and view the results',
+						`vscode://intuita.intuita-vscode-extension/case/${this.__caseHashDigest}`,
+					),
+				);
 			}
 		} catch (error) {
 			if (!(error instanceof Error)) {


### PR DESCRIPTION
I know it feels weird to add a package for such a simple task, but after my research I found out that not all terminals support hyperlink escape sequences. I've read through this package's source code and it does a pretty simple job at using 2 others packages, which are `ansi-escapes` and `supports-hyperlinks`. It then proceeds to check whether current terminal supports hyperlinks and provides a nice fallback in case it doesn't. Otherwise uses an escape sequence to insert a link. I've found it easier to install one package instead of 2 others.