### PR TITLE
fix: ensured target and targetPaths do not get initial values, fix glob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 dist
 .turbo
 package
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@ node_modules
 dist
 .turbo
 package
-
-coverage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "intuita",
-	"version": "0.5.2",
+	"version": "0.5.3",
 	"description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
 	"type": "module",
 	"exports": null,

--- a/src/buildOptions.ts
+++ b/src/buildOptions.ts
@@ -3,7 +3,6 @@ import {
 	DEFAULT_DRY_RUN,
 	DEFAULT_EXCLUDE_PATTERNS,
 	DEFAULT_INCLUDE_PATTERNS,
-	DEFAULT_INPUT_DIRECTORY_PATH,
 	DEFAULT_THREAD_COUNT,
 	DEFAULT_USE_CACHE,
 	DEFAULT_USE_JSON,
@@ -46,13 +45,11 @@ export const buildOptions = <T extends {}>(y: Argv<T>) => {
 				.option('target', {
 					type: 'string',
 					description: 'Input directory path',
-					default: DEFAULT_INPUT_DIRECTORY_PATH,
 				})
 				.option('targetPath', {
 					type: 'string',
 					description:
 						'(DEPRECATED by "target") Input directory path',
-					default: DEFAULT_INPUT_DIRECTORY_PATH,
 				})
 				.option('source', {
 					type: 'string',

--- a/src/executeMainThread.ts
+++ b/src/executeMainThread.ts
@@ -1,7 +1,6 @@
 import * as readline from 'node:readline';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import * as S from '@effect/schema/Schema';
 import { handleListNamesCommand } from './handleListCliCommand.js';
 import { CodemodDownloader } from './downloadCodemod.js';
 import { Printer } from './printer.js';
@@ -19,7 +18,7 @@ import { IFs } from 'memfs';
 import { loadRepositoryConfiguration } from './repositoryConfiguration.js';
 import { parseCodemodSettings } from './schemata/codemodSettingsSchema.js';
 import { parseFlowSettings } from './schemata/flowSettingsSchema.js';
-import { runArgvSettingsSchema } from './schemata/runArgvSettingsSchema.js';
+import { parseRunSettings } from './schemata/runArgvSettingsSchema.js';
 import { buildArgumentRecord } from './buildArgumentRecord.js';
 import { FileDownloadService } from './fileDownloadService.js';
 import Axios from 'axios';
@@ -208,7 +207,7 @@ export const executeMainThread = async () => {
 
 	const codemodSettings = parseCodemodSettings(argv);
 	const flowSettings = parseFlowSettings(argv);
-	const runSettings = S.parseSync(runArgvSettingsSchema)(argv);
+	const runSettings = parseRunSettings(homedir(), argv);
 	const argumentRecord = buildArgumentRecord(argv);
 
 	const codemodDownloader = new CodemodDownloader(
@@ -230,12 +229,11 @@ export const executeMainThread = async () => {
 		loadRepositoryConfiguration,
 		codemodSettings,
 		flowSettings,
-		runSettings.dryRun,
+		runSettings,
 		argumentRecord,
 		nameOrPath,
 		process.cwd(),
 		getCodemodSource,
-		homedir(),
 	);
 
 	await runner.run();

--- a/src/executeMainThread.ts
+++ b/src/executeMainThread.ts
@@ -28,7 +28,10 @@ import {
 	AppInsightsTelemetryService,
 	NoTelemetryService,
 } from './telemetryService.js';
-import { APP_INSIGHTS_INSTRUMENTATION_STRING } from './constants.js';
+import {
+	APP_INSIGHTS_INSTRUMENTATION_STRING,
+	DEFAULT_INPUT_DIRECTORY_PATH,
+} from './constants.js';
 import { readFile } from 'node:fs/promises';
 
 // the build script contains the version
@@ -172,7 +175,8 @@ export const executeMainThread = async () => {
 
 	if (String(argv._) === 'learn') {
 		const printer = new Printer(argv.useJson);
-		const targetPath = argv.target ?? argv.targetPath ?? null;
+		const targetPath =
+			argv.targetPath ?? argv.target ?? DEFAULT_INPUT_DIRECTORY_PATH;
 
 		try {
 			await handleLearnCliCommand(printer, targetPath);

--- a/src/fileCommands.ts
+++ b/src/fileCommands.ts
@@ -4,7 +4,7 @@ import { Options } from 'prettier';
 import { IFs } from 'memfs';
 import { filterNeitherNullNorUndefined } from './filterNeitherNullNorUndefined.js';
 import { OperationMessage } from './messages.js';
-import { RunSettings } from './runSettings.js';
+import { RunSettings } from './schemata/runArgvSettingsSchema.js';
 
 export type CreateFileCommand = Readonly<{
 	kind: 'createFile';

--- a/src/runCodemod.ts
+++ b/src/runCodemod.ts
@@ -267,8 +267,6 @@ export const runCodemod = async (
 
 		const patterns = flowSettings.files ?? flowSettings.include ?? [];
 
-		console.error('patterns', patterns);
-
 		const newPaths = await glob(patterns.slice(), {
 			absolute: true,
 			cwd: flowSettings.targetPath,
@@ -322,8 +320,6 @@ export const runCodemod = async (
 		}
 
 		const commands = await buildFormattedFileCommands(fileCommands);
-
-		console.error(commands);
 
 		for (const command of commands) {
 			await onCommand(command);

--- a/src/runCodemod.ts
+++ b/src/runCodemod.ts
@@ -265,7 +265,11 @@ export const runCodemod = async (
 			}
 		}
 
-		const newPaths = await glob(['{**/*.*,**/.*}'], {
+		const patterns = flowSettings.files ?? flowSettings.include ?? [];
+
+		console.error('patterns', patterns);
+
+		const newPaths = await glob(patterns.slice(), {
 			absolute: true,
 			cwd: flowSettings.targetPath,
 			// @ts-expect-error type inconsistency
@@ -318,6 +322,8 @@ export const runCodemod = async (
 		}
 
 		const commands = await buildFormattedFileCommands(fileCommands);
+
+		console.error(commands);
 
 		for (const command of commands) {
 			await onCommand(command);

--- a/src/runCodemod.ts
+++ b/src/runCodemod.ts
@@ -261,7 +261,7 @@ export const runCodemod = async (
 			}
 		}
 
-		const newPaths = await glob(['{**/*.*,**/.*}'], {
+		const newPaths = await glob(['**'], {
 			absolute: true,
 			cwd: flowSettings.targetPath,
 			// @ts-expect-error type inconsistency

--- a/src/runCodemod.ts
+++ b/src/runCodemod.ts
@@ -18,7 +18,7 @@ import { OperationMessage } from './messages.js';
 import { SafeArgumentRecord } from './safeArgumentRecord.js';
 import { FlowSettings } from './schemata/flowSettingsSchema.js';
 import { WorkerThreadMessage } from './workerThreadMessages.js';
-import { RunSettings } from './runSettings.js';
+import { RunSettings } from './schemata/runArgvSettingsSchema.js';
 
 const TERMINATE_IDLE_THREADS_TIMEOUT = 30 * 1000;
 
@@ -219,6 +219,7 @@ export const runCodemod = async (
 				flowSettings,
 				{
 					dryRun: false,
+					caseHashDigest: runSettings.caseHashDigest,
 				},
 				async (command) => {
 					commands.push(command);
@@ -255,13 +256,16 @@ export const runCodemod = async (
 
 				await modifyFileSystemUponCommand(
 					mfs,
-					{ dryRun: false },
+					{
+						dryRun: false,
+						caseHashDigest: runSettings.caseHashDigest,
+					},
 					command,
 				);
 			}
 		}
 
-		const newPaths = await glob(['**'], {
+		const newPaths = await glob(['{**/*.*,**/.*}'], {
 			absolute: true,
 			cwd: flowSettings.targetPath,
 			// @ts-expect-error type inconsistency

--- a/src/runRepomod.ts
+++ b/src/runRepomod.ts
@@ -46,7 +46,7 @@ export type Dependencies = Readonly<{
 export const runRepomod = async (
 	fileSystem: IFs,
 	filemod: Filemod<Dependencies, Record<string, unknown>>,
-	inputPath: string,
+	targetPath: string,
 	formatWithPrettier: boolean,
 	safeArgumentRecord: SafeArgumentRecord,
 	onPrinterMessage: (message: OperationMessage) => void,
@@ -125,7 +125,7 @@ export const runRepomod = async (
 	const externalFileCommands = await executeFilemod(
 		api,
 		filemod,
-		inputPath,
+		targetPath,
 		{
 			...safeArgumentRecord[0],
 		},
@@ -143,7 +143,7 @@ export const runRepomod = async (
 						oldPath: externalFileCommand.path,
 						oldData: '', // TODO get the old data from the filemod
 						newData: externalFileCommand.data,
-						formatWithPrettier,
+						formatWithPrettier, // TODO have a list of extensions that prettier supports
 					};
 				} catch (error) {
 					return {

--- a/src/runSettings.ts
+++ b/src/runSettings.ts
@@ -1,8 +1,0 @@
-export type RunSettings =
-	| Readonly<{
-			dryRun: false;
-	  }>
-	| Readonly<{
-			dryRun: true;
-			outputDirectoryPath: string;
-	  }>;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -218,6 +218,8 @@ export class Runner {
 					async (command) => {
 						await this._handleCommand(command);
 
+						console.error(1);
+
 						await surfaceAgnosticCaseService.emitJob(command);
 					},
 					(message) => this._printer.printMessage(message),

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -218,8 +218,6 @@ export class Runner {
 					async (command) => {
 						await this._handleCommand(command);
 
-						console.error(1);
-
 						await surfaceAgnosticCaseService.emitJob(command);
 					},
 					(message) => this._printer.printMessage(message),

--- a/src/schemata/flowSettingsSchema.ts
+++ b/src/schemata/flowSettingsSchema.ts
@@ -18,9 +18,7 @@ export const flowSettingsSchema = S.struct({
 		() => DEFAULT_EXCLUDE_PATTERNS,
 	),
 	target: S.optional(S.string),
-	targetPath: S.optional(S.string).withDefault(
-		() => DEFAULT_INPUT_DIRECTORY_PATH,
-	),
+	targetPath: S.optional(S.string),
 	files: S.optional(S.array(S.string)),
 	fileLimit: S.optional(
 		S.number.pipe(S.int()).pipe(S.positive()),
@@ -31,13 +29,19 @@ export const flowSettingsSchema = S.struct({
 	threadCount: S.optional(S.number).withDefault(() => DEFAULT_THREAD_COUNT),
 });
 
-export type FlowSettings = Omit<S.To<typeof flowSettingsSchema>, 'target'>;
+export type FlowSettings = Omit<
+	S.To<typeof flowSettingsSchema>,
+	'target' | 'targetPath'
+> & { targetPath: string };
 
 export const parseFlowSettings = (input: unknown): FlowSettings => {
 	const flowSettings = S.parseSync(flowSettingsSchema)(input);
 
 	return {
 		...flowSettings,
-		targetPath: flowSettings.target ?? flowSettings.targetPath,
+		targetPath:
+			flowSettings.targetPath ??
+			flowSettings.target ??
+			DEFAULT_INPUT_DIRECTORY_PATH,
 	};
 };

--- a/src/schemata/runArgvSettingsSchema.ts
+++ b/src/schemata/runArgvSettingsSchema.ts
@@ -1,10 +1,64 @@
 import * as S from '@effect/schema/Schema';
+import { randomBytes } from 'node:crypto';
+import { join } from 'node:path';
 
-export const runArgvSettingsSchema = S.union(
+const runArgvSettingsSchema = S.union(
 	S.struct({
 		dryRun: S.optional(S.literal(false)).withDefault(() => false),
 	}),
 	S.struct({
 		dryRun: S.literal(true),
+		outputDirectoryPath: S.optional(S.string),
 	}),
 );
+
+export type RunSettings =
+	| Readonly<{
+			dryRun: false;
+			caseHashDigest: Buffer;
+	  }>
+	| Readonly<{
+			dryRun: true;
+			streamingEnabled: boolean;
+			outputDirectoryPath: string;
+			caseHashDigest: Buffer;
+	  }>;
+
+export const parseRunSettings = (
+	homeDirectoryPath: string,
+	input: unknown,
+): RunSettings => {
+	const caseHashDigest = randomBytes(20);
+
+	const flowSettings = S.parseSync(runArgvSettingsSchema)(input);
+
+	if (flowSettings.dryRun === false) {
+		return {
+			dryRun: false,
+			caseHashDigest,
+		};
+	}
+
+	if (flowSettings.outputDirectoryPath !== undefined) {
+		return {
+			dryRun: true,
+			streamingEnabled: false,
+			outputDirectoryPath: flowSettings.outputDirectoryPath,
+			caseHashDigest,
+		};
+	}
+
+	const outputDirectoryPath = join(
+		homeDirectoryPath,
+		'.intuita',
+		'cases',
+		caseHashDigest.toString('base64url'),
+	);
+
+	return {
+		dryRun: true,
+		streamingEnabled: true,
+		outputDirectoryPath,
+		caseHashDigest,
+	};
+};

--- a/src/services/surfaceAgnosticCaseService.ts
+++ b/src/services/surfaceAgnosticCaseService.ts
@@ -1,11 +1,11 @@
 import { IFs } from 'memfs';
 import { join } from 'path';
-import { RunSettings } from '../runSettings.js';
 import { FlowSettings } from '../schemata/flowSettingsSchema.js';
 import { ArgumentRecord } from '../schemata/argumentRecordSchema.js';
 import { buildSurfaceAgnosticJob } from '../buildSurfaceAgnosticJob.js';
 import { FormattedFileCommand } from '../fileCommands.js';
 import { CaseWritingService } from '@intuita-inc/utilities';
+import { RunSettings } from '../schemata/runArgvSettingsSchema.js';
 
 export class SurfaceAgnosticCaseService {
 	protected _caseWritingService: CaseWritingService | null = null;
@@ -15,7 +15,6 @@ export class SurfaceAgnosticCaseService {
 		private readonly _runSettings: RunSettings,
 		private readonly _flowSettings: FlowSettings,
 		private readonly _argumentRecord: ArgumentRecord,
-		private readonly _caseHashDigest: Buffer,
 		private readonly _codemodHashDigest: Buffer,
 	) {}
 
@@ -36,7 +35,7 @@ export class SurfaceAgnosticCaseService {
 		this._caseWritingService = new CaseWritingService(fileHandle);
 
 		await this._caseWritingService?.writeCase({
-			caseHashDigest: this._caseHashDigest.toString('base64url'),
+			caseHashDigest: this._runSettings.caseHashDigest.toString('base64url'),
 			codemodHashDigest: this._codemodHashDigest.toString('base64url'),
 			createdAt: BigInt(Date.now()),
 			absoluteTargetPath: this._flowSettings.targetPath,

--- a/src/services/surfaceAgnosticCaseService.ts
+++ b/src/services/surfaceAgnosticCaseService.ts
@@ -53,6 +53,8 @@ export class SurfaceAgnosticCaseService {
 			return;
 		}
 
+		console.log('emittingJob', command);
+
 		await this._caseWritingService.writeJob(
 			buildSurfaceAgnosticJob(
 				this._runSettings.outputDirectoryPath,

--- a/src/services/surfaceAgnosticCaseService.ts
+++ b/src/services/surfaceAgnosticCaseService.ts
@@ -53,8 +53,6 @@ export class SurfaceAgnosticCaseService {
 			return;
 		}
 
-		console.log('emittingJob', command);
-
 		await this._caseWritingService.writeJob(
 			buildSurfaceAgnosticJob(
 				this._runSettings.outputDirectoryPath,

--- a/src/services/surfaceAgnosticCaseService.ts
+++ b/src/services/surfaceAgnosticCaseService.ts
@@ -19,7 +19,7 @@ export class SurfaceAgnosticCaseService {
 	) {}
 
 	public async emitPreamble(): Promise<void> {
-		if (!this._runSettings.dryRun) {
+		if (!this._runSettings.dryRun || !this._runSettings.streamingEnabled) {
 			return;
 		}
 
@@ -35,7 +35,8 @@ export class SurfaceAgnosticCaseService {
 		this._caseWritingService = new CaseWritingService(fileHandle);
 
 		await this._caseWritingService?.writeCase({
-			caseHashDigest: this._runSettings.caseHashDigest.toString('base64url'),
+			caseHashDigest:
+				this._runSettings.caseHashDigest.toString('base64url'),
 			codemodHashDigest: this._codemodHashDigest.toString('base64url'),
 			createdAt: BigInt(Date.now()),
 			absoluteTargetPath: this._flowSettings.targetPath,
@@ -44,7 +45,11 @@ export class SurfaceAgnosticCaseService {
 	}
 
 	public async emitJob(command: FormattedFileCommand): Promise<void> {
-		if (!this._runSettings.dryRun || this._caseWritingService === null) {
+		if (
+			!this._runSettings.dryRun ||
+			!this._runSettings.streamingEnabled ||
+			this._caseWritingService === null
+		) {
 			return;
 		}
 
@@ -57,7 +62,11 @@ export class SurfaceAgnosticCaseService {
 	}
 
 	public async emitPostamble(): Promise<void> {
-		if (!this._runSettings.dryRun || this._caseWritingService === null) {
+		if (
+			!this._runSettings.dryRun ||
+			!this._runSettings.streamingEnabled ||
+			this._caseWritingService === null
+		) {
 			return;
 		}
 

--- a/src/workerThreadManager.ts
+++ b/src/workerThreadManager.ts
@@ -71,6 +71,8 @@ export class WorkerThreadManager {
 					const filename =
 						typeof global.__filename === 'string'
 							? global.__filename
+							: typeof __filename === 'string'
+							? __filename
 							: './src/index.ts';
 
 					const worker = new Worker(filename);

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -7,6 +7,8 @@ import { RepositoryConfiguration } from '../src/repositoryConfiguration.js';
 import { equal } from 'node:assert';
 import { CodemodSettings } from '../src/schemata/codemodSettingsSchema.js';
 import { FlowSettings } from '../src/schemata/flowSettingsSchema.js';
+import { RunSettings } from '../src/schemata/runArgvSettingsSchema.js';
+import { randomBytes } from 'node:crypto';
 
 const CODEMOD_D_INDEX_TS = `
 export default function transform(file, api, options) {
@@ -104,7 +106,6 @@ describe('Runner', function () {
 		};
 
 		const currentWorkingDirectory = '/';
-		const homedir = '/home/abc';
 
 		const getCodemodSource = async (path: string) => {
 			const data = await ifs.promises.readFile(path);
@@ -114,6 +115,11 @@ describe('Runner', function () {
 			}
 
 			return data.toString('utf8');
+		};
+
+		const runSettings: RunSettings = {
+			dryRun: false,
+			caseHashDigest: randomBytes(20),
 		};
 
 		const runner = new Runner(
@@ -126,12 +132,11 @@ describe('Runner', function () {
 			loadRepositoryConfiguration,
 			codemodSettings,
 			flowSettings,
-			false,
+			runSettings,
 			{},
 			null,
 			currentWorkingDirectory,
 			getCodemodSource,
-			homedir,
 		);
 
 		await runner.run();


### PR DESCRIPTION
Changes:
1. `target` and `targetPath` do not get the initial values from `yargs` (they get them when we calculate the final targetPath)
2. `targetPath` is defined as `const targetPath =  argv.targetPath ?? argv.target ?? DEFAULT_INPUT_DIRECTORY_PATH;`
3. `RunSettings` got expanded to have a boolean that allows or disallows streaming
4. during dry-runs, files will be deleted only if they were explicitly deleted by commands, not if they just disappeared from the memFS
5. `buildPathGenerator` has now 2 arguments, the previous 3rd and 4th were not used at all
6. when creating workers, we check for both `global.__filename` and `__filename`
7. globbing in the dry-runs is not done using arbitrary globs, but by the patterns passed by the user