### PR TITLE
fix: INT-2360 post-publish codemod sync

### DIFF
--- a/src/executeMainThread.ts
+++ b/src/executeMainThread.ts
@@ -27,10 +27,7 @@ import {
 	AppInsightsTelemetryService,
 	NoTelemetryService,
 } from './telemetryService.js';
-import {
-	APP_INSIGHTS_INSTRUMENTATION_STRING,
-	DEFAULT_INPUT_DIRECTORY_PATH,
-} from './constants.js';
+import { APP_INSIGHTS_INSTRUMENTATION_STRING } from './constants.js';
 import { readFile } from 'node:fs/promises';
 import { handleLoginCliCommand } from './handleLoginCliCommand.js';
 import { handlePublishCliCommand } from './handlePublishCliCommand.js';

--- a/src/executeMainThread.ts
+++ b/src/executeMainThread.ts
@@ -274,17 +274,8 @@ export const executeMainThread = async () => {
 	if (String(argv._) === 'publish') {
 		const printer = new Printer(argv.useJson);
 
-		const codemodDownloader = new CodemodDownloader(
-			printer,
-			join(homedir(), '.intuita'),
-			false,
-			fileDownloadService,
-			tarService,
-		);
-
 		try {
 			await handlePublishCliCommand(
-				codemodDownloader,
 				printer,
 				argv.sourcePath ?? argv.source ?? process.cwd(),
 			);

--- a/src/handlePublishCliCommand.ts
+++ b/src/handlePublishCliCommand.ts
@@ -104,19 +104,18 @@ export const handlePublishCliCommand = async (
 		`Published the "${pkg.name}" package successfully`,
 	);
 
-	await mkdir(intuitaDirectoryPath, { recursive: true });
-
 	const newCodemodPath = createHash('ripemd160')
 		.update(pkg.name)
 		.digest('base64url');
 	const syncDirectory = join(intuitaDirectoryPath, newCodemodPath);
+	await mkdir(syncDirectory, { recursive: true });
 
 	try {
 		await writeFile(join(syncDirectory, 'config.json'), configJsonData);
 		await writeFile(join(syncDirectory, 'index.cjs'), indexCjsData);
 		if (descriptionMdData) {
 			await writeFile(
-				join(syncDirectory, 'index.cjs'),
+				join(syncDirectory, 'description.md'),
 				descriptionMdData,
 			);
 		}

--- a/src/handlePublishCliCommand.ts
+++ b/src/handlePublishCliCommand.ts
@@ -4,7 +4,6 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { object, string, parse } from 'valibot';
 import { publish, validateAccessToken } from './apis.js';
-import { CodemodDownloader } from './downloadCodemod.js';
 import FormData from 'form-data';
 import { mkdir, writeFile } from 'fs/promises';
 import { createHash } from 'crypto';
@@ -15,7 +14,6 @@ const packageJsonSchema = object({
 });
 
 export const handlePublishCliCommand = async (
-	codemodDownloader: CodemodDownloader,
 	printer: PrinterBlueprint,
 	sourcePath: string,
 ) => {


### PR DESCRIPTION
This PR changes allow to sync a codemod that has been published without needing to download it from the cloud.